### PR TITLE
nfsnobody deprecated in RHEL8 and above

### DIFF
--- a/tasks/set-facts.yml
+++ b/tasks/set-facts.yml
@@ -6,12 +6,20 @@
     _nfs_server_service: "nfs-kernel-server"
   when: ansible_os_family == "Debian"
 
-- name: set-facts | Setting RedHat Facts
+- name: set-facts | Setting RedHat Facts pre-8
   set_fact:
     _nfs_server_group: "nfsnobody"
     _nfs_server_owner: "nfsnobody"
     _nfs_server_service: "nfs-server"
-  when: ansible_os_family == "RedHat"
+  when: ( ansible_os_family == "RedHat" and ansible_distribution_major_version <= "7" ) 
+
+#https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/considerations_in_adopting_rhel_8/index#the-nobody-user-replaces-nfsnobody_shells-and-command-line-tools
+- name: set-facts | Setting RedHat Facts post-8
+  set_fact:
+    _nfs_server_group: "nobody"
+    _nfs_server_owner: "nobody"
+    _nfs_server_service: "nfs-server"
+  when: ( ansible_os_family == "RedHat" and ansible_distribution_major_version >= "8" )
 
 - name: set-facts | Setting Suse Facts
   set_fact:


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
nfsnobody is deprecated on RHEL8 and replaced by nobody
## Related Issue

<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
