### PR TITLE
/etc/exports block improvements and validation/reverting of /etc/expo…

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -24,12 +24,40 @@
   with_items: '{{ nfs_server_exports }}'
   when: nfs_server_exports is defined
 
+- name: Backup /etc/exports
+  ansible.builtin.copy:
+    src: /etc/exports
+    dest: /etc/exports_bck
+    owner: root
+    group: root
+    mode: '0644'
+    remote_src: yes
+
 - name: config | Configuring /etc/exports
-  template:
-    src: "etc/exports.j2"
-    dest: "/etc/exports"
-    owner: "root"
-    group: "root"
-    mode: "u=rw,g=r,o=r"
+  blockinfile:
+    dest: /etc/exports
+    block: "{{ lookup('template', 'etc/exports.j2', template_vars=dict(tpl=item)) }}"
+    marker: "# {mark} ANSIBLE MANAGED BLOCK FOR {{ item['path'] }}"
+    create: yes
+    mode: "{{ item['mode'] }}"
+  with_items: '{{ nfs_server_exports }}'
   become: true
   notify: "restart {{ _nfs_server_service }}"
+
+- name: Effecting changes in /etc/exports
+  ansible.builtin.command: 'exportfs -r'
+  register: exportfs_output
+  ignore_errors: true
+
+- name: Reverting /etc/exports if failed
+  ansible.builtin.copy:
+    src: /etc/exports_bck
+    dest: /etc/exports
+    owner: root
+    group: root
+    mode: '0644'
+    remote_src: yes
+  when: "exportfs_output.stderr != ''"
+
+- fail: msg="/etc/exports could not be validated"
+  when: "exportfs_output.stderr != ''"

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -44,6 +44,13 @@
   become: true
   notify: "restart {{ _nfs_server_service }}"
 
+- name: Restart {{ _nfs_server_service }}
+  service:
+    name: "nfs-server"
+    state: "restarted"
+    enabled: true
+  become: true  
+
 - name: Effecting changes in /etc/exports
   ansible.builtin.command: 'exportfs -r'
   register: exportfs_output

--- a/templates/etc/exports.j2
+++ b/templates/etc/exports.j2
@@ -1,9 +1,3 @@
-# {{ ansible_managed }}
-
-{% if nfs_server_exports is defined %}
-{%   for item1 in nfs_server_exports %}
-{%     for item2 in item1['access'] %}
-{{ item1['path'] }}    {{ item2['hostname'] }}({{ item2['options']|join(',') }})
-{%     endfor %}
-{%   endfor %}
-{% endif %}
+{%  for item in tpl['access'] %}
+{{ tpl['path'] }}    {{ item['hostname'] }}({{ item['options']|join(',') }})
+{%  endfor %}


### PR DESCRIPTION
## Description
I attempted to improve how config.yml creates one single block for exports in /etc/exports which is a bit hard to manage as a whole, especially when same config is needed/used on the client for syncing purposes. Now each export is a separate block which can easily be updated in sync of the config on the client side.

Before it was

```
# Ansible managed

/opt/mnt/path1    192.168.56.201(rw,sync,no_subtree_check,no_root_squash)
/opt/mnt/path2    192.168.56.201(rw,sync,no_subtree_check,no_root_squash)
```
Now 
```
# BEGIN ANSIBLE MANAGED BLOCK FOR /opt/mnt/path1
/opt/mnt/path1    192.168.56.201(rw,sync,no_subtree_check,no_root_squash)
# END ANSIBLE MANAGED BLOCK FOR /opt/mnt/path1
# BEGIN ANSIBLE MANAGED BLOCK FOR /opt/mnt/path2
/opt/mnt/path2    192.168.56.201(rw,sync,no_subtree_check,no_root_squash)
# END ANSIBLE MANAGED BLOCK FOR /opt/mnt/path2
```
Also i added some tasks for validating (exportfs -r) /etc/exports and reverting the file in case of any issue before the server gets rebooted.
